### PR TITLE
Fix `loseWhen` conditions

### DIFF
--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -115,7 +115,7 @@ public class StageManager : MonoBehaviour
     {
         int MostHP()
         {
-            var topPlayers = UIManagers.GroupBy(p => p.hp).OrderByDescending(g => g.Key).FirstOrDefault();
+            var topPlayers = UIManagers.Where(p => activePlayers.Contains(p.player)).GroupBy(p => p.hp).OrderByDescending(g => g.Key).FirstOrDefault();
             if (topPlayers?.Count() == 1)
                 return topPlayers.First().player;
             return -1; // tie
@@ -123,7 +123,7 @@ public class StageManager : MonoBehaviour
 
         int MostScore()
         {
-            var topPlayers = UIManagers.GroupBy(p => p.score).OrderByDescending(g => g.Key).FirstOrDefault();
+            var topPlayers = UIManagers.Where(p => activePlayers.Contains(p.player)).GroupBy(p => p.score).OrderByDescending(g => g.Key).FirstOrDefault();
             if (topPlayers?.Count() == 1)
                 return topPlayers.First().player;
             return -1; // tie


### PR DESCRIPTION
`loseWhenHPZero` and `loseWhenScoreZero` weren't preventing players from winning, as these conditions cause players to be removed from active player list, but when determining a winner, said list isn't checked.

This fix adds the requirement to be on the active list in order to win.